### PR TITLE
Add extraArgs config to allow user to set up autocorrection arguments for haml-lint (e.g. -a, -A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,4 @@ Haml Lint for Visual Studio Code.
 
 - `hamlLint.executablePath`: Path to haml-lint executable (default: `haml-lint`)
 - `hamlLint.useBundler`: Use `bundle exec` to run haml-lint. If this is true, the hamlLint.executablePath setting is ignored. (default: `false`)
+- `hamlLint.extraArgs`: Provide additional arguments to haml-lint. Example: '-a' to enable safe auto-corrections, or '-A' to auto-correct all offenses.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
           "type": "boolean",
           "default": false,
           "description": "Use `bundle exec` to run haml-lint. (If this is true, the hamlLint.executablePath setting is ignored.)"
+        },
+        "hamlLint.extraArgs": {
+          "type": "string",
+          "default": "",
+          "description": "Provide additional arguments to haml-lint. Example: '-a' to enable safe auto-corrections, or '-A' to auto-correct all offenses."
         }
       }
     }

--- a/src/Linter.ts
+++ b/src/Linter.ts
@@ -67,10 +67,13 @@ export default class Linter {
     }
 
     const config = workspace.getConfiguration("hamlLint");
-    const args = `--reporter json ${document.uri.fsPath}`;
+    const args = [`--reporter json ${document.uri.fsPath}`];
+    if (config.extraArgs) {
+      args.push(config.extraArgs);
+    }
     const command = config.useBundler
-      ? `bundle exec haml-lint ${args}`
-      : `${config.executablePath} ${args}`;
+      ? `bundle exec haml-lint ${args.join(' ')}`
+      : `${config.executablePath} ${args.join(' ')}`;
 
     const process = execa.command(command, {
       cwd: workspaceFolder.uri.fsPath,


### PR DESCRIPTION
Related to #6

This allows us to set an `-A` argument to run all autocorrections whenever the linter is run. It's not quite the same as "format on save", but it seems to be working for me so far.